### PR TITLE
Fix alignment of PC in ADR and LDR instructions

### DIFF
--- a/arm6.inc
+++ b/arm6.inc
@@ -95,7 +95,7 @@ calminstruction adr? dst, label*
 	arrange		error, =err 'destination must be low register'
 	assemble	error
 
-cont:	compute		address, label - (($ + 4) and 0xFC)
+cont:	compute		address, label - (($ + 4) and 0xFFFFFFFC)
 	check		address mod 4 = 0
 	jyes		rangecheck
 	arrange		error, =err 'label must be 4 aligned'
@@ -727,7 +727,7 @@ literal:
 	arrange		error, =err 'label must be 4 aligned'
 	assemble	error
 rangecheck:
-	compute		arm6.@src.value, arm6.@src.value - (($ + 4) and 0xFC)
+	compute		arm6.@src.value, arm6.@src.value - (($ + 4) and 0xFFFFFFFC)
 	check		arm6.@src.value <= 1020 & arm6.@src.value >= 0
 	jyes		litfinish
 	arrange		error, =err 'label is too far'

--- a/arm6.inc
+++ b/arm6.inc
@@ -95,7 +95,7 @@ calminstruction adr? dst, label*
 	arrange		error, =err 'destination must be low register'
 	assemble	error
 
-cont:	compute		address, label - ($ + 4)
+cont:	compute		address, label - (($ + 4) and 0xFC)
 	check		address mod 4 = 0
 	jyes		rangecheck
 	arrange		error, =err 'label must be 4 aligned'
@@ -727,7 +727,7 @@ literal:
 	arrange		error, =err 'label must be 4 aligned'
 	assemble	error
 rangecheck:
-	compute		arm6.@src.value, arm6.@src.value - ($ + 4)
+	compute		arm6.@src.value, arm6.@src.value - (($ + 4) and 0xFC)
 	check		arm6.@src.value <= 1020 & arm6.@src.value >= 0
 	jyes		litfinish
 	arrange		error, =err 'label is too far'


### PR DESCRIPTION
Per the ARMv6-M Architecture Reference Manual section A5.1.2, when using the PC register as an address offset, it must be word aligned after adding 4 (which is equal to adding 4 and setting the lower 2 bits to 0).

P.S. Thanks for creating this project! It has been a godsend for bare-metal rp2040 development :)